### PR TITLE
Port to 1.12.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,3 +118,53 @@ artifacts {
 }
 
 build.dependsOn deobfJar, apiJar
+/*
+// deployment
+configurations { deployerJars }
+dependencies { deployerJars "org.apache.maven.wagon:wagon-ssh:2.2" }
+apply plugin: 'maven'
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            configuration = configurations.deployerJars
+            repository(url: "scp://maven.foxiehost.lan/home/maven/public/") {
+                authentication(userName: "maven", password: "maven")
+            }
+            pom {
+                groupId = project.group
+                version = project.version
+                artifactId = project.archivesBaseName
+                project {
+                    name project.archivesBaseName
+                    packaging 'jar'
+                    description 'Calendar'
+                    url 'http://foxiemods.com/Calendar'
+                    scm {
+                        url 'https://github.com/CallMeFoxie/Calendar'
+                        connection 'scm:git:git@github.com:CallMeFoxie/Calendar.git'
+                        developerConnection 'scm:git:git@github.com:CallMeFoxie/Calendar.git'
+                    }
+                    issueManagement {
+                        system 'github'
+                        url 'https://github.com/CallMeFoxie/Calendar/issues'
+                    }
+                    licenses {
+                        license {
+                            name 'TBD'
+                            url 'https://does-not-exist'
+                            distribution 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id 'CallMeFoxie'
+                            name 'CallMeFoxie'
+                            roles { role 'developer' }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+*/

--- a/build.gradle
+++ b/build.gradle
@@ -11,70 +11,88 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
     }
 }
 
 apply plugin: 'net.minecraftforge.gradle.forge'
+//Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
-ext.configFile = file "build.properties"
 
-configFile.withReader {
-    def prop = new Properties()
-    prop.load(it)
-    project.ext.config = new ConfigSlurper().parse prop
-}
-
-def VersionBuild = 0
-if (System.getenv("BUILD_NUMBER") != null) {
-    def buildver = System.getenv("BUILD_NUMBER")
-    VersionBuild = "-${buildver}"
-}
-
-version = "${config.minecraft_version}-${config.mod_version}${VersionBuild}"
+version = "1.12.2-2.1.0"
 group = "foxie"
 archivesBaseName = "BetterSleeping"
 
+sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+compileJava {
+    sourceCompatibility = targetCompatibility = '1.8'
+}
+
 minecraft {
-    version = config.minecraft_version + "-" + config.forge_version
+    version = "1.12.2-14.23.5.2768"
     runDir = "run"
-    mappings = config.mappings
-    replaceIn "foxie/bettersleeping/BetterSleeping.java"
-    replace "@VERSION@", "${config.mod_version}"
+    
+    // the mappings can be changed at any time, and must be in the following format.
+    // snapshot_YYYYMMDD   snapshot are built nightly.
+    // stable_#            stables are built at the discretion of the MCP team.
+    // Use non-default mappings at your own risk. they may not always work.
+    // simply re-run your setup task after changing the mappings to update your workspace.
+    mappings = "snapshot_20171003"
+    // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
 repositories {
-    maven {
-        name "OpenMods"
-        url "http://repo.openmods.info/artifactory/openmods"
-    }
-
     maven {
         name "Foxiehost"
         url "http://maven.foxiehost.eu"
     }
 }
 
+
 dependencies {
-    compile(group: 'openblocks', name: 'OpenBlocks-API', version: '1.1')
-    compile "foxie:FoxieLib:1.10.2-1.0-9:deobf"
-    compile "foxie:Calendar:1.10.2-1.5-10:deobf"
+    // you may put jars on which you depend on in ./libs
+    // or you may define them like so..
+    //compile "some.group:artifact:version:classifier"
+    //compile "some.group:artifact:version"
+      
+    // real examples
+    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
+    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
+
+    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
+    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+
+    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
+    // except that these dependencies get remapped to your current MCP mappings
+    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+
+    // for more info...
+    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
+    // http://www.gradle.org/docs/current/userguide/dependency_management.html
+    compile files("libs/FoxieLib-1.12.2-1.1.0-deobf.jar")
+    compile files("libs/Calendar-1.12.2-1.6.0-deobf.jar")
 }
 
-processResources
-        {
-            inputs.property "version", project.version
-            inputs.property "mcversion", project.minecraft.version
+processResources {
+    // this will ensure that this task is redone when the versions change.
+    inputs.property "version", project.version
+    inputs.property "mcversion", project.minecraft.version
 
-            from(sourceSets.main.resources.srcDirs) {
-                include 'mcmod.info'
+    // replace stuff in mcmod.info, nothing else
+    from(sourceSets.main.resources.srcDirs) {
+        include 'mcmod.info'
+                
+        // replace version and mcversion
+        expand 'version':project.version, 'mcversion':project.minecraft.version
+    }
+        
+    // copy everything else except the mcmod.info
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'mcmod.info'
+    }
+}
 
-                expand 'version': project.version, 'mcversion': project.minecraft.version
-            }
-            from(sourceSets.main.resources.srcDirs) {
-                exclude 'mcmod.info'
-            }
-        }
 jar {
     manifest {
         attributes 'FMLCorePlugin': 'foxie.bettersleeping.asm.BetterSleepingCoreLoader'
@@ -100,55 +118,3 @@ artifacts {
 }
 
 build.dependsOn deobfJar, apiJar
-
-// deployment
-configurations { deployerJars }
-dependencies { deployerJars "org.apache.maven.wagon:wagon-ssh:2.2" }
-
-apply plugin: 'maven'
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-
-            repository(url: "scp://maven.foxiehost.lan/home/maven/public/") {
-                authentication(userName: "maven", password: "maven")
-            }
-
-            pom {
-                groupId = project.group
-                version = project.version
-                artifactId = project.archivesBaseName
-                project {
-                    name project.archivesBaseName
-                    packaging 'jar'
-                    description 'BetterSleeping2'
-                    url 'http://foxiemods.com/BetterSleeping2'
-                    scm {
-                        url 'https://github.com/CallMeFoxie/BetterSleeping2'
-                        connection 'scm:git:git@github.com:CallMeFoxie/BetterSleeping2.git'
-                        developerConnection 'scm:git:git@github.com:CallMeFoxie/BetterSleeping2.git'
-                    }
-                    issueManagement {
-                        system 'github'
-                        url 'https://github.com/CallMeFoxie/BetterSleeping2/issues'
-                    }
-                    licenses {
-                        license {
-                            name 'TBD'
-                            url 'https://does-not-exist'
-                            distribution 'repo'
-                        }
-                    }
-                    developers {
-                        developer {
-                            id 'CallMeFoxie'
-                            name 'CallMeFoxie'
-                            roles { role 'developer' }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}

--- a/src/main/java/foxie/bettersleeping/api/BetterSleepingAPI.java
+++ b/src/main/java/foxie/bettersleeping/api/BetterSleepingAPI.java
@@ -1,6 +1,5 @@
 package foxie.bettersleeping.api;
 
-
 import foxie.bettersleeping.SaveHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;

--- a/src/main/java/foxie/bettersleeping/api/PlayerSleepEvent.java
+++ b/src/main/java/foxie/bettersleeping/api/PlayerSleepEvent.java
@@ -1,6 +1,5 @@
 package foxie.bettersleeping.api;
 
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;

--- a/src/main/java/foxie/bettersleeping/client/EnergyGuiOverlay.java
+++ b/src/main/java/foxie/bettersleeping/client/EnergyGuiOverlay.java
@@ -60,7 +60,7 @@ public class EnergyGuiOverlay extends GuiScreen {
       drawTexturedModalRect((int) (guiOffsetLeft + percent), guiOffsetTop, 0, 8, 8, 8);
 
       if (renderBedIcon)
-         itemRender.renderItemAndEffectIntoGUI(new ItemStack(Items.BED), guiOffsetLeft + 36, guiOffsetTop - 4);
+         itemRender.renderItemAndEffectIntoGUI(new ItemStack(Items.BED, 1, 14), guiOffsetLeft + 36, guiOffsetTop - 4);
 
    }
 }

--- a/src/main/java/foxie/bettersleeping/commands/CommandGetEnergy.java
+++ b/src/main/java/foxie/bettersleeping/commands/CommandGetEnergy.java
@@ -7,16 +7,26 @@ import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 
+import javax.annotation.Nullable;
+import java.util.List;
+
 public class CommandGetEnergy extends CommandBase {
+
    @Override
-   public String getCommandName() {
+   public String getUsage(ICommandSender sender) {
       return "getenergy";
    }
 
    @Override
-   public String getCommandUsage(ICommandSender sender) {
+   public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
+      return super.getTabCompletions(server, sender, args, targetPos);
+   }
+
+   @Override
+   public String getName() {
       return "getenergy";
    }
 
@@ -29,7 +39,7 @@ public class CommandGetEnergy extends CommandBase {
 
       PlayerBSData data = BetterSleepingAPI.getSleepingProperty(player);
 
-      player.addChatMessage(new TextComponentTranslation("message.energyGet", data.getEnergy()));
+      player.sendMessage(new TextComponentTranslation("message.energyGet", data.getEnergy()));
 
    }
 }

--- a/src/main/java/foxie/bettersleeping/commands/CommandSetEnergy.java
+++ b/src/main/java/foxie/bettersleeping/commands/CommandSetEnergy.java
@@ -7,17 +7,27 @@ import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 
+import javax.annotation.Nullable;
+import java.util.List;
+
 public class CommandSetEnergy extends CommandBase {
+
    @Override
-   public String getCommandName() {
-      return "setenergy";
+   public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
+      return super.getTabCompletions(server, sender, args, targetPos);
    }
 
    @Override
-   public String getCommandUsage(ICommandSender sender) {
-      return "setenergy <new tiredness>";
+   public String getUsage(ICommandSender sender) {
+       return "setenergy <new tiredness>";
+   }
+
+   @Override
+   public String getName() {
+       return "setenergy";
    }
 
    @Override
@@ -31,7 +41,7 @@ public class CommandSetEnergy extends CommandBase {
          PlayerBSData data = BetterSleepingAPI.getSleepingProperty(player);
 
          data.setEnergy(Long.decode(args[0]));
-         sender.addChatMessage(new TextComponentTranslation("message.energySet"));
+         sender.sendMessage(new TextComponentTranslation("message.energySet"));
       }
    }
 }

--- a/src/main/java/foxie/bettersleeping/modules/BedModule.java
+++ b/src/main/java/foxie/bettersleeping/modules/BedModule.java
@@ -16,12 +16,12 @@ public class BedModule extends Module {
 
    @SubscribeEvent
    public void isProperTime(PlayerSleepInBedEvent event) {
-      if (event.getEntityPlayer().worldObj.isRemote)
+      if (event.getEntityPlayer().world.isRemote)
          return;
 
-      long time = event.getEntityPlayer().worldObj.getWorldTime() % 24000;
+      long time = event.getEntityPlayer().world.getWorldTime() % 24000;
       if (time < minTime && minTime >= -1 || time > maxTime && minTime >= -1) {
-         event.getEntityPlayer().addChatComponentMessage(new TextComponentTranslation("message.notSleepNow"));
+         event.getEntityPlayer().sendMessage(new TextComponentTranslation("message.notSleepNow"));
          event.setResult(EntityPlayer.SleepResult.OTHER_PROBLEM);
       }
    }

--- a/src/main/java/foxie/bettersleeping/modules/DebuffModule.java
+++ b/src/main/java/foxie/bettersleeping/modules/DebuffModule.java
@@ -68,7 +68,7 @@ public class DebuffModule extends Module {
 
    @SubscribeEvent
    public void playerTick(TickEvent.PlayerTickEvent event) {
-      if (event.phase != TickEvent.Phase.START || event.player.worldObj.isRemote || !TirednessModule.doPlayersGetTired())
+      if (event.phase != TickEvent.Phase.START || event.player.world.isRemote || !TirednessModule.doPlayersGetTired())
          return;
 
       PlayerBSData data = BetterSleepingAPI.getSleepingProperty(event.player);
@@ -90,7 +90,7 @@ public class DebuffModule extends Module {
       if (sleepOnGroundPotions.length == 0 || sleepOnGroundPotionLength == 0)
          return;
 
-      String potionId = sleepOnGroundPotions[event.getPlayer().worldObj.rand.nextInt(sleepOnGroundPotions.length)];
+      String potionId = sleepOnGroundPotions[event.getPlayer().world.rand.nextInt(sleepOnGroundPotions.length)];
       if (Potion.getPotionFromResourceLocation(potionId) == null) {
          FoxLog.error("Tried applying bad potion type while sleeping on the ground. Potion ID: " + potionId);
          return;
@@ -104,7 +104,7 @@ public class DebuffModule extends Module {
       if (sleepInBedPotions.length == 0 || sleepInBedPotionLength == 0)
          return;
 
-      String potionId = sleepInBedPotions[event.getPlayer().worldObj.rand.nextInt(sleepInBedPotions.length)];
+      String potionId = sleepInBedPotions[event.getPlayer().world.rand.nextInt(sleepInBedPotions.length)];
       if (Potion.getPotionFromResourceLocation(potionId) == null) {
          FoxLog.error("Tried applying bad potion type while sleeping in the bed. Potion ID: " + potionId);
          return;

--- a/src/main/java/foxie/bettersleeping/modules/RandomModule.java
+++ b/src/main/java/foxie/bettersleeping/modules/RandomModule.java
@@ -16,11 +16,11 @@ public class RandomModule extends Module {
 
    @SubscribeEvent
    public void onPlayerUseBed(PlayerSleepInBedEvent event) {
-      if (alwaysSetSpawn && !event.getEntityPlayer().worldObj.isRemote) {
+      if (alwaysSetSpawn && !event.getEntityPlayer().world.isRemote) {
          BlockPos blockpos = null;
          try {
-            blockpos = event.getEntityPlayer().worldObj.getBlockState(event.getEntityPlayer().getPosition()).
-                    getBlock().getBedSpawnPosition(null, event.getEntityPlayer().worldObj,
+            blockpos = event.getEntityPlayer().world.getBlockState(event.getEntityPlayer().getPosition()).
+                    getBlock().getBedSpawnPosition(null, event.getEntityPlayer().world,
                     event.getEntityPlayer().getPosition(), event.getEntityPlayer());
 
          } catch (Exception ignored) {
@@ -32,7 +32,7 @@ public class RandomModule extends Module {
 
          event.getEntityPlayer().setSpawnPoint(blockpos, false);
 
-         event.getEntityPlayer().addChatMessage(new TextComponentTranslation("message.spawnSet"));
+         event.getEntityPlayer().sendMessage(new TextComponentTranslation("message.spawnSet"));
       }
    }
 

--- a/src/main/java/foxie/bettersleeping/modules/TirednessModule.java
+++ b/src/main/java/foxie/bettersleeping/modules/TirednessModule.java
@@ -70,7 +70,7 @@ public class TirednessModule extends Module {
 
    @SubscribeEvent
    public void playerSlept(PlayerSleepEvent.PlayerSleptEvent event) {
-      if (event.getPlayer().worldObj.isRemote)
+      if (event.getPlayer().world.isRemote)
          return;
 
       PlayerBSData data = BetterSleepingAPI.getSleepingProperty(event.getPlayer());
@@ -90,7 +90,7 @@ public class TirednessModule extends Module {
 
    @SubscribeEvent
    public void playerTick(TickEvent.PlayerTickEvent event) {
-      if (event.player.worldObj.isRemote || !playersGetTired || event.player.capabilities.isCreativeMode)
+      if (event.player.world.isRemote || !playersGetTired || event.player.capabilities.isCreativeMode)
          return;
 
       PlayerBSData data = BetterSleepingAPI.getSleepingProperty(event.player);
@@ -122,7 +122,7 @@ public class TirednessModule extends Module {
 
    @SubscribeEvent
    public void sleepOnGroundEvent(PlayerSleepEvent.SleepOnGroundEvent event) {
-      if (event.getPlayer().worldObj.isRemote)
+      if (event.getPlayer().world.isRemote)
          return;
 
       if (sleepOnGroundAt < 0 && event.isCancelable())
@@ -208,20 +208,20 @@ public class TirednessModule extends Module {
 
    @SubscribeEvent
    public void playerSlept(PlayerSleepInBedEvent event) {
-      if (event.getEntityPlayer().worldObj.isRemote || !playersGetTired)
+      if (event.getEntityPlayer().world.isRemote || !playersGetTired)
          return;
 
       PlayerBSData data = BetterSleepingAPI.getSleepingProperty(event.getEntityPlayer());
 
       if (data.getEnergy() > maximumEnergy && capEnergy || data.getEnergy() > minimumEnergy) {
-         event.getEntityPlayer().addChatMessage(new TextComponentTranslation("message.notTired"));
+         event.getEntityPlayer().sendMessage(new TextComponentTranslation("message.notTired"));
          event.setResult(EntityPlayer.SleepResult.OTHER_PROBLEM);
       }
    }
 
    @SubscribeEvent
    public void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
-      if (event.player.worldObj.isRemote)
+      if (event.player.world.isRemote)
          return;
 
       PlayerBSData data = BetterSleepingAPI.getSleepingProperty(event.player);
@@ -230,7 +230,7 @@ public class TirednessModule extends Module {
 
    @SubscribeEvent
    public void isPlayerFullyAsleep(PlayerSleepEvent.IsPlayerFullyAsleepEvent event) {
-      if (event.getEntityPlayer().worldObj.isRemote)
+      if (event.getEntityPlayer().world.isRemote)
          return;
 
       if (!event.getEntityPlayer().isPlayerSleeping() || event.getTimer() < dozingTimer)

--- a/src/main/java/foxie/bettersleeping/network/MessageSleepPls.java
+++ b/src/main/java/foxie/bettersleeping/network/MessageSleepPls.java
@@ -23,7 +23,7 @@ public class MessageSleepPls implements IMessage, IMessageHandler<MessageSleepPl
    @Override
    public IMessage onMessage(final MessageSleepPls message, final MessageContext ctx) {
 
-      final EntityPlayer player = ctx.getServerHandler().playerEntity;
+      final EntityPlayer player = ctx.getServerHandler().player;
       final BlockPos pos = player.getPosition();
       if (player.isPlayerSleeping())
          return null;

--- a/src/main/java/foxie/bettersleeping/proxy/ProxyCommon.java
+++ b/src/main/java/foxie/bettersleeping/proxy/ProxyCommon.java
@@ -21,6 +21,6 @@ public class ProxyCommon {
    }
 
    public IThreadListener getThreadListener(MessageContext ctx) {
-      return (IThreadListener) ctx.getServerHandler().playerEntity.worldObj;
+      return (IThreadListener) ctx.getServerHandler().player.world;
    }
 }

--- a/src/main/resources/assets/bettersleeping/lang/en_US.lang
+++ b/src/main/resources/assets/bettersleeping/lang/en_US.lang
@@ -1,9 +1,0 @@
-death.attack.coffeeOverdose=%s has died from coffee overdose!
-death.attack.pillOverdose=%s has died from nomming on too many pills!
-death.attack.tiredness=%s has tired themselves to death!
-message.notTired=You are not tired enough to sleep!
-message.energySet=The energy has been set for you.
-message.energyGet=Your current energy is %s.
-message.spawnSet=Your spawn has been set.
-message.notSleepNow=You cannot sleep at this time.
-key.gotosleep=Sleep

--- a/src/main/resources/assets/bettersleeping/lang/en_us.lang
+++ b/src/main/resources/assets/bettersleeping/lang/en_us.lang
@@ -1,0 +1,9 @@
+death.attack.coffeeOverdose=%s has died from coffee overdose!
+death.attack.pillOverdose=%s has died from nomming on too many pills!
+death.attack.tiredness=%s has tired themselves to death!
+message.notTired=You are not tired enough to sleep!
+message.energySet=The energy has been set for you.
+message.energyGet=Your current energy is %s.
+message.spawnSet=Your spawn has been set.
+message.notSleepNow=You cannot sleep at this time.
+key.gotosleep=Sleep

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 1,
+    "pack_format": 3,
     "description": "Resources used for BetterSleeping"
   }
 }


### PR DESCRIPTION
**[THIS PULL REQUEST IS WORK IN PROGRESS]**

Seems that your Better Sleeping mod was slightly abandoned and no work done here since February 2017, so I made a port to 1.12.2. Some players as me wanted to port it and play with this mod on 1.12.2.

Some notes: 
This PR pushes changes to master branch, create one for 1.10.2 to avoid troubles. (but still saved in master branch in my fork).
This is port with disabled deployment in build.gradle, because old ones isn't working properly for me and causing lots of errors, mostly with "config" thing. (feel free to ask for changes in your gradle file, if you need)
Also, check out PRs in Calendar API and FoxieLib repositories, because they need to play/build mod with Better Sleeping.

Some explanations of changes:
- Now bed have 16 variants and I added meta 14 to get back the red bed.
- Changed command methods, because old ones was renamed.
- worldObj was renamed to just world and addChatMessage was renamed to sendMessage.
- Fixed pack.mcmeta's version and now it's v3 and .lang file works fine.
- Built with Forge 14.23.5.2768 (to build or if you want to play with port, check out releases of my fork of FoxieLib and Calendar API)

If you do not want to push this port and upload it, can it be as unofficial port of Better Sleeping?
P.S. I'm slighty bad at English, so feel free to ask questions.